### PR TITLE
Fix 'FileField' not working in form decorator

### DIFF
--- a/object_tool/shortcuts.py
+++ b/object_tool/shortcuts.py
@@ -78,7 +78,7 @@ def _confirm_view(form_class=None, short_description="", template=None, confirm_
             form = None
 
             if request.method == "POST" and request.POST.get(confirm_field):
-                form = form_class and form_class(request.POST)
+                form = form_class and form_class(request.POST, request.FILES)
                 if not form or form.is_valid():
                     return func(modeladmin, request, form, obj) if form\
                         else func(modeladmin, request, obj)

--- a/object_tool/templates/admin/object_tool/form.html
+++ b/object_tool/templates/admin/object_tool/form.html
@@ -13,7 +13,7 @@
 <hr>
 <br>
 <div id="content-main">
-  <form method="POST">{% csrf_token %}
+  <form method="POST" enctype="multipart/form-data">{% csrf_token %}
     {% if confirm_text %}<p>{{ confirm_text }}</p>{% endif %}
     {% if form %}{{ form }}{% endif %}
     <div class="submit-row">


### PR DESCRIPTION
Hi, @Xavier-Lam,

i've been using your library for a while and i found an issue with the `FileField` when using the `@form` decorator.

The problem is that you can't upload any file on submit due to `form_class` not receiving `request.FILES` and missing the `enctype` attribute on the form.

I have fixed it and it's working correctly on my projects.

Please let me know if i'ts ok to pull and publish this fix on `pypi`.